### PR TITLE
added .env.sample and updating other files to use values from the .env file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,6 @@
+COOKIE_SECRET=insert-random-string
+TWILIO_ACCOUNT_SID=add-twilio-sid-here
+TWILIO_AUTH_TOKEN=add-auth-token-here
+TWILIO_PHONE_NUMBER=+15555555555
+PHONE_ENCRYPTION_KEY=insert-random-string
+DATABASE_URL=postgres://localhost:5432/courtbot

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Specifically, the twilio features include:
 
 First, install [node](https://github.com/codeforamerica/howto/blob/master/Node.js.md), [postgres](https://github.com/codeforamerica/howto/blob/master/PostgreSQL.md).
 
+Since the app uses twilio to send text messages, it requires a bit of configuration. Get a [twilio account](http://www.twilio.com/), create a .env file by running `mv .env.sample .env`, and add your twilio authentication information. While you're there, add a cookie secret and an encryption key (long random strings).
+
 Then, to create the tables and load in initial data:
 
 ```console
@@ -19,8 +21,6 @@ node utils/createQueuedTable.js
 node utils/createRemindersTable.js
 node runners/load.js
 ```
-
-Since the app uses twilio to send text messages, it requires a bit of configuration. Get a [twilio account](http://www.twilio.com/), create a .env file by running `mv .env.sample .env`, and add your twilio authentication information. While you're there, add a cookie secret and an encryption key (long random strings).
 
 To start the web service:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@ Specifically, the twilio features include:
 
 First, install [node](https://github.com/codeforamerica/howto/blob/master/Node.js.md), [postgres](https://github.com/codeforamerica/howto/blob/master/PostgreSQL.md).
 
-Since the app uses twilio to send text messages, it requires a bit of configuration. Get a [twilio account](http://www.twilio.com/), create a .env file by running `mv .env.sample .env`, and add your twilio authentication information. While you're there, add a cookie secret and an encryption key (long random strings).
+Since the app uses twilio to send text messages, it requires a bit of configuration. Get a [twilio account](http://www.twilio.com/), create a .env file by running `cp .env.sample .env`, and add your twilio authentication information. While you're there, add a cookie secret and an encryption key (long random strings).
+
+Install node dependencies
+
+```console
+npm install
+```
 
 Then, to create the tables and load in initial data:
 

--- a/db.js
+++ b/db.js
@@ -1,8 +1,9 @@
 var crypto = require('crypto');
 var Knex = require('knex');
+require('dotenv').config();
 var knex = Knex.initialize({
   client: 'pg',
-  connection: process.env.DATABASE_URL || 'localhost',
+  connection: process.env.DATABASE_URL,
   pool: {
     afterCreate: function(connection, callback) {
       connection.query("SET TIME ZONE 'America/Anchorage';", function(err) {

--- a/utils/createQueuedTable.js
+++ b/utils/createQueuedTable.js
@@ -1,9 +1,10 @@
 // Creates the reminders table.
 var Knex = require('knex');
+require('dotenv').config();
 
 var knex = Knex.initialize({
   client: 'pg',
-  connection: process.env.DATABASE_URL || 'localhost'
+  connection: process.env.DATABASE_URL
 });
 
 var createTable = function() {

--- a/utils/createRemindersTable.js
+++ b/utils/createRemindersTable.js
@@ -1,9 +1,10 @@
 // Creates the reminders table.
 var Knex = require('knex');
+require('dotenv').config();
 
 var knex = Knex.initialize({
   client: 'pg',
-  connection: process.env.DATABASE_URL || 'localhost'
+  connection: process.env.DATABASE_URL
 });
 
 var createTable = function() {

--- a/utils/loaddata.js
+++ b/utils/loaddata.js
@@ -6,11 +6,12 @@ var request = require('request');
 var parse = require('csv-parse');
 var Promise = require('bluebird');
 var sha1 = require('sha1');
+require('dotenv').config();
 
 var Knex = require('knex');
 var knex = Knex.initialize({
   client: 'pg',
-  connection: process.env.DATABASE_URL || 'localhost',
+  connection: process.env.DATABASE_URL,
   pool: {
     min: 0,
     max: 7,

--- a/web.js
+++ b/web.js
@@ -3,6 +3,7 @@ var express = require('express');
 var logfmt = require('logfmt');
 var moment = require('moment');
 var db = require('./db');
+require('dotenv').config();
 
 var app = express();
 


### PR DESCRIPTION
With this change, you should be able to follow the instructions in the readme and not have to pass additional environment variables when running things