### PR TITLE
Close #25. Ignore signatures and emoticons in incoming SMS

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "chai": "^2.1.2",
     "csv-parse": "0.0.1",
     "dotenv": "^1.1.0",
+    "emoji-strip": "^1.0.1",
     "express": "~3.4.8",
     "knex": "^0.12.2",
     "logfmt": "~0.23.0",

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <h3>Input</h3>
     <form action="/sms" method="POST" target="my_iframe">
         number: <input name="From" value="9075551234"/> <br>
-        message: <input name="Body"/> <br>
+        message: <textarea name="Body"></textarea> <br>
         <input type="submit"/>
     </form>
 

--- a/test/web_test.js
+++ b/test/web_test.js
@@ -167,7 +167,7 @@ describe("POST /sms", function() {
         });
       });
 
-      it.only("strips emojis from a text", function (done) {
+      it("strips emojis from a text", function (done) {
         sess.post('/sms')
           .send({
             Body: '4928456 😁',

--- a/test/web_test.js
+++ b/test/web_test.js
@@ -114,7 +114,6 @@ describe("GET /cases", function() {
     });
   });
 
-
   it("doesnt find partial matches of id", function(done) {
     knex('cases').del().then(function() {
       knex('cases').insert([turnerData()]).then(function() {
@@ -166,6 +165,48 @@ describe("POST /sms", function() {
           expect(res.text).to.equal('<?xml version="1.0" encoding="UTF-8"?><Response><Sms>Found a case for Frederick Turner scheduled on Fri, Mar 27th at 1:00 PM, at CNVCRT. Would you like a courtesy reminder the day before? (reply YES or NO)</Sms></Response>');
           done();
         });
+      });
+
+      it.only("strips emojis from a text", function (done) {
+        sess.post('/sms')
+          .send({
+            Body: '4928456 😁',
+            From: "+12223334444"
+          })
+          .expect(200)
+          .end(function(err, res) {
+            if(err) return done(err);
+            expect(res.text).to.equal('<?xml version="1.0" encoding="UTF-8"?><Response><Sms>Found a case for Frederick Turner scheduled on Fri, Mar 27th at 1:00 PM, at CNVCRT. Would you like a courtesy reminder the day before? (reply YES or NO)</Sms></Response>');
+            done();
+          });
+      });
+
+      it("strips everything after newlines and carriage returns from id", function (done) {
+        sess.post('/sms')
+          .send({
+            Body: '4928456\r\n-Simon',
+            From: "+12223334444"
+          })
+          .expect(200)
+          .end(function(err, res) {
+            if(err) return done(err);
+            expect(res.text).to.equal('<?xml version="1.0" encoding="UTF-8"?><Response><Sms>Found a case for Frederick Turner scheduled on Fri, Mar 27th at 1:00 PM, at CNVCRT. Would you like a courtesy reminder the day before? (reply YES or NO)</Sms></Response>');
+            done();
+          });
+      });
+
+      it("strips everything after newlines and carriage returns from id", function (done) {
+        sess.post('/sms')
+          .send({
+            Body: '4928456\n-Simon',
+            From: "+12223334444"
+          })
+          .expect(200)
+          .end(function(err, res) {
+            if(err) return done(err);
+            expect(res.text).to.equal('<?xml version="1.0" encoding="UTF-8"?><Response><Sms>Found a case for Frederick Turner scheduled on Fri, Mar 27th at 1:00 PM, at CNVCRT. Would you like a courtesy reminder the day before? (reply YES or NO)</Sms></Response>');
+            done();
+          });
       });
 
       it("sets match and askedReminder on session", function(done) {
@@ -495,7 +536,7 @@ context("with session.askedQueued", function() {
 });
 
 function turnerData(v) {
-  return { 
+  return {
     //date: '27-MAR-15',
     date: TEST_UTC_DATE,
     defendant: 'Frederick Turner',

--- a/web.js
+++ b/web.js
@@ -166,7 +166,7 @@ var cleanupName = function (name) {
 };
 
 function cleanupText (text) {
-  text = text.replace(/[\r\n|\n].*/g, '', '');
+  text = text.replace(/[\r\n|\n].*/g, '');
 
   text = emojiStrip(text);
   text = text.trim();

--- a/web.js
+++ b/web.js
@@ -4,6 +4,8 @@ var logfmt = require('logfmt');
 var db = require('./db');
 var dates = require("./utils/dates");
 var rollbar = require('rollbar');
+var emojiStrip = require('emoji-strip');
+
 require('dotenv').config();
 
 var app = express();
@@ -79,7 +81,7 @@ function askedReminderMiddleware(req, res, next) {
 // Respond to text messages that come in from Twilio
 app.post('/sms', askedReminderMiddleware, function (req, res, next) {
   var twiml = new twilio.TwimlResponse();
-  var text = req.body.Body.toUpperCase();
+  var text = cleanupText(req.body.Body.toUpperCase());
 
   if (req.askedReminder) {
     if (isResponseYes(text)) {
@@ -150,7 +152,6 @@ app.post('/sms', askedReminderMiddleware, function (req, res, next) {
       req.session.askedReminder = true;
     }
 
-
     res.send(twiml.toString());
   });
 });
@@ -164,10 +165,19 @@ var cleanupName = function (name) {
   return name;
 };
 
+function cleanupText (text) {
+  text = text.replace(/[\r\n|\n].*/g, '', '');
+
+  text = emojiStrip(text);
+  text = text.trim();
+  return text;
+}
+
 function isResponseYes(text) {
   text = text.toUpperCase().trim();
   return (text === 'YES' || text === 'YEA' || text === 'YUP' || text === 'Y');
 }
+
 function isResponseNo(text) {
   text = text.toUpperCase().trim();
   return (text === 'NO' || text === 'N');
@@ -181,13 +191,13 @@ app.use(function (err, req, res, next) {
     console.log("Error: " + err.message);
     rollbar.handleError(err, req);
     if (app.settings.env !== 'production') {
-      return res.status(500).send(err.stack)
+      return res.status(500).send(err.stack);
     }
 
-    return res.status(500).send('Sorry, internal server error')
+    return res.status(500).send('Sorry, internal server error');
   }
 });
-// Send all uncaught excpetions to Rollbar???
+// Send all uncaught exceptions to Rollbar???
 var options = {
   exitOnUncaughtException: true
 };


### PR DESCRIPTION
Added emojiStrip and stripping all text after a newline for incoming SMSes. 