### PR TITLE
Fix deprecation error in moment calls

### DIFF
--- a/utils/dates.js
+++ b/utils/dates.js
@@ -16,16 +16,29 @@ module.exports = {
 
 	/**
 	 * UTC timezone offset in minutes
-	 * @atDate - Effective date for the offset
+	 * @atDate - Effective date for the offset (MM/DD/YYYY, YYYY-MM-DD, moment, or default to today if null)
 	 * @return {int} offset
 	 */
 	timezoneOffset: function(atDate) {
-		var dt = atDate ? atDate : moment().format("YYYY-MM-DD");
+		var dt = "";
+		if (atDate) {
+			if (typeof atDate == "string") {
+				if (atDate.indexOf("/") == -1)  {
+					dt = atDate;   // String in YYYY-MM-DD already
+				} else {
+					dt = moment(atDate, "MM/DD/YYYY").format("YYYY-MM-DD");   // String in MM/DD/YYYY
+				}
+			} else {
+				dt = atDate.format("YYYY-MM-DD");    // Moment object
+			}
+		} else {
+			dt = moment().format("YYYY-MM-DD");      // Default to today
+		}
 		var tz = moment.tz(dt, process.env.TIMEZONE).format('Z');
 		console.log("Date: " + moment(dt).format("YYYY-MM-DD") + " Offset: " + tz);
 		return tz;
 	},
-	
+
 	/**
 	 * Get current moment timestamp, using our environment timezone.
 	 * @return {moment} moment object


### PR DESCRIPTION
We were depending on correct moment.js implied behavior for a bunch of different date formats passed into the timezoneOffset function. This caused warnings like the below when running tests. I put in brute force code to handle the different formats the function might get. Messy, but should be safer.

_Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are discouraged and will be removed in an upcoming major release. Please refer to http://momentjs.com/guides/#/warnings/js-date/ for more info.
Arguments: 
[0] _isAMomentObject: true, _isUTC: true, _useUTC: true, _l: undefined, _i: 10/04/2016, _f: undefined, _strict: undefined, _locale: [object Object]
Error
    at Function.createFromInputFallback (/home/tescher/node-projects/courtbot/node_modules/moment-timezone/node_modules/moment/moment.js:320:94)
    at configFromString (/home/tescher/node-projects/courtbot/node_modules/moment-timezone/node_modules/moment/moment.js:2178:11)
    at configFromInput (/home/tescher/node-projects/courtbot/node_modules/moment-timezone/node_modules/moment/moment.js:2547:9)
    at prepareConfig (/home/tescher/node-projects/courtbot/node_modules/moment-timezone/node_modules/moment/moment.js:2530:9)
    at createFromConfig (/home/tescher/node-projects/courtbot/node_modules/moment-timezone/node_modules/moment/moment.js:2497:40)
    at createLocalOrUTC (/home/tescher/node-projects/courtbot/node_modules/moment-timezone/node_modules/moment/moment.js:2584:12)
    at createUTC (/home/tescher/node-projects/courtbot/node_modules/moment-timezone/node_modules/moment/moment.js:87:12)
    at Function.tz (/home/tescher/node-projects/courtbot/node_modules/moment-timezone/moment-timezone.js:484:22)
    at Object.module.exports.timezoneOffset (/home/tescher/node-projects/courtbot/utils/dates.js:24:19)
    at Object.module.exports.fromDateAndTime (/home/tescher/node-projects/courtbot/utils/dates.js:68:58)
    at /home/tescher/node-projects/courtbot/utils/loaddata.js:80:19
    at Array.forEach (native)
    at extractCourtData (/home/tescher/node-projects/courtbot/utils/loaddata.js:63:8)
    at /home/tescher/node-projects/courtbot/utils/loaddata.js:35:23
    at null.<anonymous> (/home/tescher/node-projects/courtbot/node_modules/csv-parse/lib/index.js:305:16)
    at EventEmitter.emit (events.js:117:20)
    at finishMaybe (_stream_writable.js:356:12)
    at endWritable (_stream_writable.js:363:3)
    at Writable.end (_stream_writable.js:341:5)
    at /home/tescher/node-projects/courtbot/node_modules/csv-parse/lib/index.js:285:21
    at process._tickCallback (node.js:415:13)_