### PR TITLE
Allow reminder requests same day as original hearing

### DIFF
--- a/test/send_reminders_test.js
+++ b/test/send_reminders_test.js
@@ -59,13 +59,13 @@ describe("with one reminder that hasn't been sent", function() {
     });
 });
 
-describe("with two reminders that haven't been sent", function () {
+describe("with three reminders (including one duplicate) that haven't been sent", function () {
     beforeEach(function (done) {
         manager.ensureTablesExist()
             .then(clearTable("cases"))
             .then(clearTable("reminders"))
             .then(loadCases([case1, case2]))
-            .then(addTestReminders([reminder1, reminder2]))
+            .then(addTestReminders([reminder1, reminder2, reminder2_dup]))
             .then(function() { done(); })
             .catch(done);
     });
@@ -84,7 +84,7 @@ describe("with two reminders that haven't been sent", function () {
                 sendReminders().then(function (res) {
                     knex("reminders").where({ sent: true }).select("*").then(function (rows) {
                         console.log(JSON.stringify(rows));
-                        expect(rows.length).to.equal(2);
+                        expect(rows.length).to.equal(3);
                         done();
                     })
                     .catch(done);
@@ -163,10 +163,17 @@ var reminder1 = {
     caseId: case1.id,
     phone: "+12223334444",
     originalCase: case1
-}
+};
 
 var reminder2 = {
     caseId: case2.id,
     phone: "+12223334445",
     originalCase: case2
-}
+};
+
+var reminder2_dup = {
+    caseId: case2.id,
+    phone: "+12223334445",
+    originalCase: case2
+};
+

--- a/test/web_test.js
+++ b/test/web_test.js
@@ -288,9 +288,9 @@ describe("POST /sms", function() {
               if (err) {
                 return done(err);
               }
-              expect(res.text).to.equal('<?xml version="1.0" encoding="UTF-8"?><Response><Sms>Found a case for Frederick Turner scheduled on Mon, Mar 2nd at 1:00 PM, at CNVCRT. Can&apos;t set reminders for hearings happening the same day.</Sms></Response>');
+              expect(res.text).to.equal('<?xml version="1.0" encoding="UTF-8"?><Response><Sms>Found a case for Frederick Turner scheduled today at 1:00 PM, at CNVCRT. Would you like a courtesy reminder the day before a future hearing? (reply YES or NO)</Sms></Response>');
               expect(getConnectCookie().askedQueued).to.equal(undefined);
-              expect(getConnectCookie().askedReminder).to.equal(undefined);
+              expect(getConnectCookie().askedReminder).to.equal(true);
               expect(getConnectCookie().citationId).to.equal(undefined);
               done();
             });
@@ -305,9 +305,9 @@ describe("POST /sms", function() {
               if (err) {
                 return done(err);
               }
-              expect(res.text).to.equal('<?xml version="1.0" encoding="UTF-8"?><Response><Sms>Found a case for Frederick Turner scheduled on Mon, Mar 2nd at 12:00 PM, at CNVCRT. It appears your hearing has already occurred.</Sms></Response>');
+              expect(res.text).to.equal('<?xml version="1.0" encoding="UTF-8"?><Response><Sms>Found a case for Frederick Turner scheduled today at 12:00 PM, at CNVCRT. Would you like a courtesy reminder the day before a future hearing? (reply YES or NO)</Sms></Response>');
               expect(getConnectCookie().askedQueued).to.equal(undefined);
-              expect(getConnectCookie().askedReminder).to.equal(undefined);
+              expect(getConnectCookie().askedReminder).to.equal(true);
               expect(getConnectCookie().citationId).to.equal(undefined);
               done();
             });
@@ -322,9 +322,9 @@ describe("POST /sms", function() {
               if (err) {
                 return done(err);
               }
-              expect(res.text).to.equal('<?xml version="1.0" encoding="UTF-8"?><Response><Sms>Found a case for Frederick Turner scheduled on Mon, Mar 2nd at 10:00 AM, at CNVCRT. It appears your hearing has already occurred.</Sms></Response>');
+              expect(res.text).to.equal('<?xml version="1.0" encoding="UTF-8"?><Response><Sms>Found a case for Frederick Turner scheduled today at 10:00 AM, at CNVCRT. Would you like a courtesy reminder the day before a future hearing? (reply YES or NO)</Sms></Response>');
               expect(getConnectCookie().askedQueued).to.equal(undefined);
-              expect(getConnectCookie().askedReminder).to.equal(undefined);
+              expect(getConnectCookie().askedReminder).to.equal(true);
               expect(getConnectCookie().citationId).to.equal(undefined);
               done();
             });

--- a/web.js
+++ b/web.js
@@ -152,20 +152,20 @@ app.post('/sms', askedReminderMiddleware, function (req, res, next) {
       var name = cleanupName(match.defendant);
       var datetime = dates.fromUtc(match.date);
 
-      var caseInfo = 'Found a case for ' + name + ' scheduled on ' + datetime.format("ddd, MMM Do") + ' at ' + datetime.format("h:mm A") + ', at ' + match.room + '.';
+      var caseInfo = 'Found a case for ' + name + ' scheduled ' + (datetime.isSame(dates.now(), 'd') ? 'today' : 'on ' + datetime.format("ddd, MMM Do")) + ' at ' + datetime.format("h:mm A") + ', at ' + match.room + '.';
 
-      if ((datetime.diff(dates.now()) > 0) && (datetime.isSame(dates.now(), 'd'))) {
-        twiml.sms(caseInfo + " Can\'t set reminders for hearings happening the same day.");
+      if ((datetime.diff(dates.now()) > 0) && (datetime.isSame(dates.now(), 'd'))) {   // Hearing today
+        twiml.sms(caseInfo + " Would you like a courtesy reminder the day before a future hearing? (reply YES or NO)");
       } else {
-        if (datetime.diff(dates.now()) <= 0) {
-          twiml.sms(caseInfo + " It appears your hearing has already occurred.");
+        if (datetime.diff(dates.now()) <= 0) {  // Hearing already happened
+          twiml.sms(caseInfo + " Would you like a courtesy reminder the day before a future hearing? (reply YES or NO)");
         } else {
           twiml.sms('Found a case for ' + name + ' scheduled on ' + datetime.format("ddd, MMM Do") + ' at ' + datetime.format("h:mm A") + ', at ' + match.room + '. Would you like a courtesy reminder the day before? (reply YES or NO)');
-
-          req.session.match = match;
-          req.session.askedReminder = true;
         }
       }
+
+      req.session.match = match;
+      req.session.askedReminder = true;
     }
 
     res.send(twiml.toString());


### PR DESCRIPTION
Sharon from State Courts wanted to leave in the ability to request reminders the same day as a case's hearing. This is because there can be future hearings the person is signing up for (this is new information - we thought there could only ever be one hearing for a citation). 

This creates an issue (actually can already happen) where reminder requests get set that never get resolved. We will need to create a clean-up process for old reminder requests at some point. I'll add an issue for it.