### PR TITLE
Twilio update

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
 COOKIE_SECRET=insert-random-string
-TWILIO_ACCOUNT_SID=add-twilio-sid-here
+TWILIO_ACCOUNT_SID=ACadd-twilio-sid-here
 TWILIO_AUTH_TOKEN=add-auth-token-here
 TWILIO_PHONE_NUMBER=+15555555555
 PHONE_ENCRYPTION_KEY=insert-random-string

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ utils/tmp/*
 !utils/tmp/.gitkeep
 TODO
 .idea
+.vscode/

--- a/package.json
+++ b/package.json
@@ -25,19 +25,19 @@
     "logfmt": "~0.23.0",
     "moment": "~2.5.1",
     "moment-timezone": "^0.5.5",
-    "nock": "^1.2.1",
     "pg": "^6.1.0",
     "request": "~2.34.0",
     "rollbar": "^0.6.3",
     "sha1": "~1.1.0",
     "timekeeper": "0.0.5",
-    "twilio": "~1.6.0",
+    "twilio": "~3.6.7",
     "underscore": "~1.6.0"
   },
   "devDependencies": {
     "cookie-parser": "^1.3.5",
     "mocha": "^2.2.4",
-    "sinon": "^1.15.4",
+    "nock": "^9.0.18",
+    "sinon": "^3.3.0",
     "sinon-chai": "^2.8.0",
     "supertest": "^0.15.0",
     "supertest-session": "^0.0.7"

--- a/test/date_and_time_tests.js
+++ b/test/date_and_time_tests.js
@@ -58,7 +58,7 @@ describe("for a given date", function() {
         };
 
         // test() overwrites DB data with each iteration so it's important that the tests are done sequentially
-        return TEST_HOURS.reduce((p, hr) => p.then(r=> test(hr)), Promise.resolve())
+        return TEST_HOURS.reduce((p, hr) => p.then(r => test(hr)), Promise.resolve())
     });
 });
 

--- a/test/date_and_time_tests.js
+++ b/test/date_and_time_tests.js
@@ -1,80 +1,79 @@
+'use strict';
 require('dotenv').config();
-var findReminders = require("../sendReminders.js").findReminders;
-var expect = require("chai").expect;
-var manager = require("../utils/db/manager");
+const findReminders = require("../sendReminders.js").findReminders;
+const expect = require("chai").expect;
+const manager = require("../utils/db/manager");
+const tk = require('timekeeper');
+const db = require('../db');
+const knex = manager.knex;
 
-var db = require('../db');
-var knex = manager.knex;
-
-var dates = require("../utils/dates"),
+const dates = require("../utils/dates"),
     TEST_CASE_ID = "677167760f89d6f6ddf7ed19ccb63c15486a0eab",
     TEST_HOURS = [-10,-9,-8,-7,-6,-5,-4,-3,-2,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,23.75,24,24.15,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49],
     TEST_UTC_DATE = "2015-03-27T08:00:00" + dates.timezoneOffset("2015-03-27");
 
 describe("for a given date", function() {
+    const time = new Date("2015-03-02T12:00:00" + dates.timezoneOffset("2015-03-02")); // Freeze
+
     beforeEach(function() {
+        tk.freeze(time);
+
         return manager.ensureTablesExist()
-            .then(clearTable("cases"))
-            .then(clearTable("reminders"))
-            .then(loadCases([turnerData()]))
-            .then(addTestReminder)
+        .then(clearTable("cases"))
+        .then(clearTable("reminders"))
+        .then(loadCases([turnerData()]))
+        .then(addTestReminder)
     });
 
+    afterEach(function(){
+        tk.reset();
+    })
 
     it("datetime in table matches datetime on the client", function() {
-
         return knex.select("*").from("cases").where("date", TEST_UTC_DATE)
-            .then(function(results) {
-                expect(results.length).to.equal(1);
-            });
+        .then(results =>  expect(results.length).to.equal(1));
     });
 
     it("datetime matches for all hours in a day", function() {
         this.timeout(5000); // This may take a while
-        let test = function(hr) {
-                console.log("hr: ", hr)
-                let testDateTime = dates.now().add(1, "days").hour(0).add(hr, "hours");
-                console.log("Now: ",dates.now().format());
-                return updateCaseDate(TEST_CASE_ID, testDateTime)
-                    .then(findReminders)
-                    .then(function(results) {
-                        if (results[0]) console.log(dates.fromUtc(results[0].date).format(), testDateTime.format());
-                        if ((hr >= 0) && (hr < 24)) {  // Should only find reminders for the next day
-                            console.log("Reminder found for hour ", hr)
-                            expect(results.length).to.equal(1);
-                            expect(dates.fromUtc(results[0].date).format()).to.equal(testDateTime.format());
-                            expect(results[0].time).to.equal(dates.toFormattedTime(testDateTime));
-                        } else {
-                            console.log("NO reminder found for hour ", hr)
-                            expect(results.length).to.equal(0);
-                        }
-                    });
+        const test = function(hr) {
+            console.log("hr: ", hr)
+            const testDateTime = dates.now().add(1, "days").hour(0).add(hr, "hours");
+            console.log("Now: ",dates.now().format());
+
+            return updateCaseDate(TEST_CASE_ID, testDateTime)
+            .then(findReminders)
+            .then(function(results) {
+                if (results[0]) console.log(dates.fromUtc(results[0].date).format(), testDateTime.format());
+                if ((hr >= 0) && (hr < 24)) {  // Should only find reminders for the next day
+                    console.log("Reminder found for hour ", hr)
+                    expect(results.length).to.equal(1);
+                    expect(dates.fromUtc(results[0].date).format()).to.equal(testDateTime.format());
+                    expect(results[0].time).to.equal(dates.toFormattedTime(testDateTime));
+                } else {
+                    console.log("NO reminder found for hour ", hr)
+                    expect(results.length).to.equal(0);
+                }
+            });
         };
 
         // test() overwrites DB data with each iteration so it's important that the tests are done sequentially
-        return TEST_HOURS.reduce((p, hr) =>{
-            return p.then(r=> test(hr))
-        }, Promise.resolve())
-
+        return TEST_HOURS.reduce((p, hr) => p.then(r=> test(hr)), Promise.resolve())
     });
 });
 
 function updateCaseDate(caseId, newDate) {
     console.log("Updating date to: " + newDate.format());
-    return  knex("cases")
-            .where("id", "=", caseId)
-            .update({
-                "date": newDate.format(),
-                "time": dates.toFormattedTime(newDate)
-            })
-            .then(() => knex('cases')
-                .where("id", "=", caseId)
-                .select()
-                .then(function(results) {
-                    console.log("Stored: ", results[0].date, " ",results[0].time)
-                    return results
-                })
-            )
+    return  knex("cases").where("id", "=", caseId)
+    .update({
+        "date": newDate.format(),
+        "time": dates.toFormattedTime(newDate)
+    })
+    .then(() => knex('cases').where("id", "=", caseId).select())
+    .then(function(results) {
+        console.log("Stored: ", results[0].date, " ",results[0].time)
+        return results
+    });
 }
 
 function loadCases(cases) {
@@ -85,12 +84,12 @@ function loadCases(cases) {
 };
 
 function addTestReminder() {
-       //console.log("Adding Test Reminder");
-       return  db.addReminder({
-            caseId: TEST_CASE_ID,
-            phone: "+12223334444",
-            originalCase: turnerData()
-        })
+    //console.log("Adding Test Reminder");
+    return  db.addReminder({
+        caseId: TEST_CASE_ID,
+        phone: "+12223334444",
+        originalCase: turnerData()
+    });
 };
 
 function clearTable(table) {

--- a/test/load_data_test.js
+++ b/test/load_data_test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint "no-console": "off" */
 
 // see https://mochajs.org/#arrow-functions

--- a/test/send_queued_test.js
+++ b/test/send_queued_test.js
@@ -1,99 +1,97 @@
-// Special env vars needed for NOCK consistency
-
-process.env.TWILIO_ACCOUNT_SID = "test";
-process.env.TWILIO_AUTH_TOKEN = "token";
-process.env.TWILIO_PHONE_NUMBER = "+test";
-
+'use strict';
 require('dotenv').config();
-var sendQueued = require("../sendQueued.js").sendQueued;
-var expect = require("chai").expect;
-var assert = require("chai").assert;
-var nock = require('nock');
-var now = require("../utils/dates").now;
-var manager = require("../utils/db/manager");
-var db = require('../db');
-var knex = manager.knex;
-
-nock.disableNetConnect();
-nock('https://api.twilio.com:443').log(console.log);
+const sendQueued = require("../sendQueued.js").sendQueued;
+const expect = require("chai").expect;
+const assert = require("chai").assert;
+const now = require("../utils/dates").now;
+const manager = require("../utils/db/manager");
+const db = require('../db');
+const knex = manager.knex;
+const sinon = require('sinon')
+const messages = require('../utils/messages')
 
 describe("with 2 valid queued cases (same citation)", function() {
-  beforeEach(function() {
-    function initData() {
-      return knex('cases').del()
-      .then(() => knex('cases').insert([turnerData()]))
-      .then(() => knex("queued").del())
-      .then(() => db.addQueued({ citationId: "4928456", phone: "+12223334444"}))
-      .then(() => db.addQueued({ citationId: "4928456", phone: "+12223334444"}))
-    }
-    return manager.ensureTablesExist().then(initData);
-  });
+    let messageStub
+    beforeEach(function() {
+        messageStub = sinon.stub(messages, 'send')
+        messageStub.resolves(true)
 
-  it("sends the correct info to Twilio and updates the queued to sent", function() {
-    var number = "+12223334444";
-    var msg = `Hello from the ${process.env.COURT_NAME}. We found a case for Frederick Turner scheduled on Fri, Mar 27th at 1:00 PM, at CNVCRT. Would you like a courtesy reminder the day before? (reply YES or NO)`;
+        return manager.ensureTablesExist()
+        .then(() => knex('cases').del())
+        .then(() => knex('cases').insert([turnerData()]))
+        .then(() => knex("queued").del())
+        .then(() => db.addQueued({ citationId: "4928456", phone: "+12223334444"}))
+        .then(() => db.addQueued({ citationId: "4928456", phone: "+12223334444"}))
+    });
 
-    nock('https://api.twilio.com:443')
-        .post('/2010-04-01/Accounts/test/Messages.json', "To=" + encodeURIComponent(number) + "&From=%2Btest&Body=" + encodeURIComponent(msg))
-        .reply(200, {"status":200}, { 'access-control-allow-credentials': 'true'});
+    afterEach(function(){
+        messageStub.restore()
+    });
 
-    nock('https://api.twilio.com:443')
-        .post('/2010-04-01/Accounts/test/Messages.json', "To=" + encodeURIComponent(number) + "&From=%2Btest&Body=" + encodeURIComponent(msg))
-        .reply(200, {"status":200}, { 'access-control-allow-credentials': 'true'});
+    it("sends the correct info to Twilio and updates the queued to sent", function() {
+        const number = "+12223334444";
+        const message = `Hello from the ${process.env.COURT_NAME}. We found a case for Frederick Turner scheduled on Fri, Mar 27th at 1:00 PM, at CNVCRT. Would you like a courtesy reminder the day before a future hearing? (reply YES or NO)`;
 
-    return sendQueued()
-      .then(res => knex("queued").select("*"))
-      .then(rows => {
-        //console.log("Rows: " + JSON.stringify(rows));
-        expect(rows[0].sent).to.equal(true);
-        expect(rows[0].asked_reminder).to.equal(true);
-        expect(rows[0].asked_reminder_at).to.notNull;
-        expect(rows[1].sent).to.equal(true);
-        expect(rows[1].asked_reminder).to.equal(true);
-        expect(rows[1].asked_reminder_at).to.notNull;
-      })
-  });
+        return sendQueued()
+        .then(res => knex("queued").select("*"))
+        .then(rows => {
+            expect(rows[0].sent).to.equal(true);
+            expect(rows[0].asked_reminder).to.equal(true);
+            expect(rows[0].asked_reminder_at).to.notNull;
+            expect(rows[1].sent).to.equal(true);
+            expect(rows[1].asked_reminder).to.equal(true);
+            expect(rows[1].asked_reminder_at).to.notNull;
+            sinon.assert.calledTwice(messageStub)
+            sinon.assert.alwaysCalledWithExactly(messageStub, number, process.env.TWILIO_PHONE_NUMBER, message)
+        });
+    });
 });
 
 describe("with a queued non-existent case", function() {
-  beforeEach(function() {
-    return knex('cases').del()
-    .then(() => knex('cases').insert([turnerData()]))
-    .then(() => knex("queued").del())
-    .then(() => db.addQueued({citationId: "123", phone: "+12223334444"}))
-  })
+    let messageStub
+    beforeEach(function() {
+        messageStub = sinon.stub(messages, 'send')
+        messageStub.resolves(true)
 
-  it("doesn't do anything < QUEUE_TTL days", function() {
-    return sendQueued()
-      .then(res =>  knex("queued").select("*"))
-      .then(rows => expect(rows[0].sent).to.equal(false))
-  });
+        return knex('cases').del()
+        .then(() => knex('cases').insert([turnerData()]))
+        .then(() => knex("queued").del())
+        .then(() => db.addQueued({citationId: "123", phone: "+12223334444"}))
+    });
 
-  it("sends a failure sms after QUEUE_TTL days", function() {
-    var number = "+12223334444";
-    var message = `We haven't been able to find your court case. You can go to " + process.env.COURT_PUBLIC_URL + " for more information. - ${process.env.COURT_NAME}`;
-    var mockCreatedDate = now().subtract(parseInt(process.env.QUEUE_TTL_DAYS) + 2, 'days');
+    afterEach(function(){
+        messageStub.restore()
+    });
 
-    nock('https://api.twilio.com:443')
-      .post('/2010-04-01/Accounts/test/Messages.json', "To=" + encodeURIComponent(number) + "&From=%2Btest&Body=" + encodeURIComponent(message))
-      .reply(200, {"status":200}, { 'access-control-allow-credentials': 'true'});
+    it("doesn't do anything < QUEUE_TTL days", function() {
+        return sendQueued()
+        .then(res =>  knex("queued").select("*"))
+        .then(rows => expect(rows[0].sent).to.equal(false))
+    });
 
-    return knex("queued").update({created_at: mockCreatedDate})
-    .then(() => sendQueued())
-    .then(res =>  knex("queued").select("*"))
-    .then(rows => expect(rows[0].sent).to.equal(true))
+    it("sends a failure sms after QUEUE_TTL days", function() {
+        const number = "+12223334444";
+        const message = `We haven't been able to find your court case. You can go to ${process.env.COURT_PUBLIC_URL} for more information. - ${process.env.COURT_NAME}`;
+        const mockCreatedDate = now().subtract(parseInt(process.env.QUEUE_TTL_DAYS) + 2, 'days');
 
-  });
+        return knex("queued").update({created_at: mockCreatedDate})
+        .then(() => sendQueued())
+        .then(res =>  knex("queued").select("*"))
+        .then(rows => {
+            sinon.assert.alwaysCalledWithExactly(messageStub, number, process.env.TWILIO_PHONE_NUMBER, message )
+            expect(rows[0].sent).to.equal(true)
+        });
+    });
 });
 
 function turnerData(v) {
-  return {
-    //date: '27-MAR-15',
-    date: '2015-03-27T08:00:00.000Z',
-    defendant: 'Frederick Turner',
-    room: 'CNVCRT',
-    time: '01:00:00 PM',
-    citations: '[{"id":"4928456","violation":"40-8-76.1","description":"SAFETY BELT VIOLATION","location":"27 DECAATUR ST"}]',
-    id: '677167760f89d6f6ddf7ed19ccb63c15486a0eab' + (v||"")
-  };
+    return {
+        //date: '27-MAR-15',
+        date: '2015-03-27T21:00:00.000Z',
+        defendant: 'Frederick Turner',
+        room: 'CNVCRT',
+        time: '01:00:00 PM',
+        citations: '[{"id":"4928456","violation":"40-8-76.1","description":"SAFETY BELT VIOLATION","location":"27 DECAATUR ST"}]',
+        id: '677167760f89d6f6ddf7ed19ccb63c15486a0eab' + (v||"")
+    }
 }

--- a/test/send_reminders_test.js
+++ b/test/send_reminders_test.js
@@ -1,26 +1,26 @@
-// Special env vars needed for NOCK consistency
-process.env.TWILIO_ACCOUNT_SID = "test";
-process.env.TWILIO_AUTH_TOKEN = "token";
-process.env.TWILIO_PHONE_NUMBER = "+test";
+'use strict';
 require('dotenv').config();
-var sr = require("../sendReminders.js");
-var sendReminders = sr.sendReminders;
-var findReminders = sr.findReminders;
-var expect = require("chai").expect;
-var nock = require('nock');
-var manager = require("../utils/db/manager");
-var db = require('../db');
-var knex = manager.knex;
+const sr = require("../sendReminders.js");
+const sendReminders = sr.sendReminders;
+const findReminders = sr.findReminders;
+const expect = require("chai").expect;
+const sinon = require('sinon')
+const manager = require("../utils/db/manager");
+const db = require('../db');
+const knex = manager.knex;
+const messages = require('../utils/messages')
 
-var dates = require("../utils/dates"),
+const dates = require("../utils/dates"),
     TEST_CASE_ID = "677167760f89d6f6ddf7ed19ccb63c15486a0eab",
     TEST_UTC_DATE = "2015-03-27T08:00:00" + dates.timezoneOffset("2015-03-27");
 
-nock.disableNetConnect();
-nock('https://api.twilio.com:443').log(console.log);
-
 describe("with one reminder that hasn't been sent", function() {
+    let messageStub
+
     beforeEach(function () {
+       messageStub = sinon.stub(messages, 'send')
+       messageStub.resolves(true)
+
        return manager.ensureTablesExist()
             .then(clearTable("cases"))
             .then(clearTable("reminders"))
@@ -28,32 +28,30 @@ describe("with one reminder that hasn't been sent", function() {
             .then(addTestReminders([reminder1]))
     });
 
+    afterEach(function() {
+        messageStub.restore()
+    });
+
     it("sends the correct info to Twilio and updates the reminder to sent", function() {
-        var number = "+12223334444";
-        var message1 = "(1/2) Reminder: It appears you have a court case tomorrow at 2:00 PM at NEWROOM.";
-        var message2 = `(2/2) You should confirm your case date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
+        var message = `Reminder: It appears you have a court hearing tomorrow at 2:00 PM at NEWROOM. You should confirm your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
+        return knex("cases").update({date: dates.todayAtHour(14).add(1, 'days'), time: '02:00:00 PM', room: 'NEWROOM' })
+        .then(() => sendReminders())
+        .then(() => knex("reminders").where({ sent: true }).select("*"))
+        .then(function (rows) {
+            sinon.assert.calledWith(messageStub, reminder1.phone, process.env.TWILIO_PHONE_NUMBER, message)
+            expect(rows.length).to.equal(1);
 
-        return knex("cases").update({date: dates.now().add(1, 'days'), time: '02:00:00 PM', room: 'NEWROOM' })
-            .then(function() {
-                nock('https://api.twilio.com:443')
-                    .post('/2010-04-01/Accounts/test/Messages.json', "To=" + encodeURIComponent(number) + "&From=%2Btest&Body=" + encodeURIComponent(message1))
-                    .reply(200, {"status":200}, { 'access-control-allow-credentials': 'true'});
-                nock('https://api.twilio.com:443')
-                    .post('/2010-04-01/Accounts/test/Messages.json', "To=" + encodeURIComponent(number) + "&From=%2Btest&Body=" + encodeURIComponent(message2))
-                    .reply(200, {"status":200}, { 'access-control-allow-credentials': 'true'});
-
-                return sendReminders()
-            })
-            .then(res => knex("reminders").where({ sent: true }).select("*"))
-            .then(function (rows) {
-                console.log(JSON.stringify(rows));
-                expect(rows.length).to.equal(1);
-            })
+        });
     });
 });
 
 describe("with three reminders (including one duplicate) that haven't been sent", function () {
+    let messageMock
+
     beforeEach(function () {
+        messageMock = sinon.mock(messages)
+        //messageExpectation.resolves(true)
+
         return manager.ensureTablesExist()
             .then(clearTable("cases"))
             .then(clearTable("reminders"))
@@ -61,20 +59,20 @@ describe("with three reminders (including one duplicate) that haven't been sent"
             .then(addTestReminders([reminder1, reminder2, reminder2_dup]))
     });
 
-    it("sends the correct info to Twilio and updates the reminder(s) to sent", function () {
-        nock('https://api.twilio.com:443')
-            .filteringPath(function (path) {
-                return '/';
-            })
-            .post('/')
-            .times(2)
-            .reply(200, { "status": 200 }, { 'access-control-allow-credentials': 'true' });
+    afterEach(function() {
+        messageMock.restore()
+    });
 
-        return knex("cases").update({ date: dates.now().add(1, 'days'), time: '02:00:00 PM', room: 'NEWROOM' })
+    it("sends the correct info to Twilio and updates the reminder(s) to sent", function () {
+        var message = `Reminder: It appears you have a court hearing tomorrow at 2:00 PM at NEWROOM. You should confirm your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
+        messageMock.expects('send').resolves(true).once().withExactArgs(reminder1.phone, process.env.TWILIO_PHONE_NUMBER, message)
+        messageMock.expects('send').resolves(true).twice().withExactArgs(reminder2.phone, process.env.TWILIO_PHONE_NUMBER, message)
+
+        return knex("cases").update({ date: dates.todayAtHour(14).add(1, 'days'), time: '02:00:00 PM', room: 'NEWROOM' })
         .then(() =>  sendReminders())
         .then(res =>  knex("reminders").where({ sent: true }).select("*"))
         .then(rows => {
-            console.log(JSON.stringify(rows));
+            messageMock.verify()
             expect(rows.length).to.equal(3);
         });
     });
@@ -82,34 +80,31 @@ describe("with three reminders (including one duplicate) that haven't been sent"
 
 function loadCases(cases) {
     return function() {
-        //console.log("Adding test case.");
         return knex("cases").insert(cases);
-    };
-};
+    }
+}
 
 function addTestReminders(reminders) {
     return function () {
         return Promise.all(reminders.map(function (reminder) {
             return addTestReminder(reminder);
-        }))
+        }));
     }
 }
 
 function addTestReminder(reminder) {
-    // console.log("Adding Test Reminder");
     return db.addReminder({
         caseId: reminder.caseId,
         phone: reminder.phone,
         originalCase: reminder.originalCase
-    })
+    });
 }
 
 function clearTable(table) {
     return function() {
-        //console.log("Clearing table: " + table);
         return knex(table).del()
     };
-};
+}
 
 var case1 = {
     //date: '27-MAR-15',
@@ -119,8 +114,7 @@ var case1 = {
     time: '01:00:00 PM',
     citations: '[{"id":"4928456","violation":"40-8-76.1","description":"SAFETY BELT VIOLATION","location":"27 DECAATUR ST"}]',
     id: "677167760f89d6f6ddf7ed19ccb63c15486a0eab"
-
-};
+}
 
 var case2 = {
     //date: '27-MAR-15',
@@ -130,22 +124,22 @@ var case2 = {
     time: '01:00:00 PM',
     citations: '[{"id":"4928457","violation":"40-8-78.1","description":"DRIVING TO SLOW...","location":"22 NUNYA DR"}]',
     id: "677167760f89d6f6ddf7ed19ccb63c15486a0eac"
-};
+}
 
 var reminder1 = {
     caseId: case1.id,
     phone: "+12223334444",
     originalCase: case1
-};
+}
 
 var reminder2 = {
     caseId: case2.id,
     phone: "+12223334445",
     originalCase: case2
-};
+}
 
 var reminder2_dup = {
     caseId: case2.id,
     phone: "+12223334445",
     originalCase: case2
-};
+}

--- a/utils/dates.js
+++ b/utils/dates.js
@@ -38,6 +38,13 @@ module.exports = {
 		//console.log("Date: " + moment(dt).format("YYYY-MM-DD") + " Offset: " + tz);
 		return tz;
 	},
+    /**
+	 * Get a moment object for today at given hour (24hour), using our environment timezone.
+	 * @return {moment} moment object
+	 */
+    todayAtHour: function(hour) {
+        return moment.tz(moment(hour, 'HH'), process.env.TIMEZONE).utc()
+    },
 
 	/**
 	 * Get current moment timestamp, using our environment timezone.

--- a/utils/messages.js
+++ b/utils/messages.js
@@ -148,7 +148,6 @@ function send(to, from, body) {
         to: to,
         from: from
     })
-    return Promise.resolve();
 }
 
 module.exports = {

--- a/utils/messages.js
+++ b/utils/messages.js
@@ -1,5 +1,5 @@
 const twilio = require('twilio');
-const client = twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
+const client = new twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
 
 const dates = require('./dates');
 

--- a/utils/messages.js
+++ b/utils/messages.js
@@ -1,7 +1,7 @@
 const twilio = require('twilio');
-const dates = require('./dates');
-
 const client = twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
+
+const dates = require('./dates');
 
 /**
  * reduces whitespace to a single space
@@ -143,9 +143,12 @@ function weWillRemindYou() {
  * @return {Promise} Promise to send message.
  */
 function send(to, from, body) {
-  return new Promise((resolve) => {
-    client.sendMessage({ to, from, body }, resolve);
-  });
+    return client.messages.create({
+        body: body,
+        to: to,
+        from: from
+    })
+    return Promise.resolve();
 }
 
 module.exports = {

--- a/web.js
+++ b/web.js
@@ -131,7 +131,7 @@ function askedReminderMiddleware(req, res, next) {
 
 // Respond to text messages that come in from Twilio
 app.post('/sms', askedReminderMiddleware, (req, res, next) => {
-  const twiml = new twilio.TwimlResponse();
+  const twiml = new twilio.twiml.MessagingResponse();
   const text = cleanupText(req.body.Body.toUpperCase());
   if (req.askedReminder) {
     if (isResponseYes(text)) {
@@ -141,13 +141,13 @@ app.post('/sms', askedReminderMiddleware, (req, res, next) => {
         originalCase: JSON.stringify(req.match),
       })
         .then(() => {
-          twiml.sms(messages.weWillRemindYou());
+          twiml.message(messages.weWillRemindYou());
           req.session.askedReminder = false;
           res.send(twiml.toString());
         })
         .catch(err => next(err));
     } else {
-      twiml.sms(messages.forMoreInfo());
+      twiml.message(messages.forMoreInfo());
       req.session.askedReminder = false;
       res.send(twiml.toString());
     }
@@ -161,14 +161,14 @@ app.post('/sms', askedReminderMiddleware, (req, res, next) => {
         phone: req.body.From,
       })
         .then(() => {
-          twiml.sms(messages.weWillKeepLooking());
+          twiml.message(messages.weWillKeepLooking());
           req.session.askedQueued = false;
           res.send(twiml.toString());
         })
         .catch(err => next(err));
       return;
     } else if (isResponseNo(text)) {
-      twiml.sms(messages.forMoreInfo());
+      twiml.message(messages.forMoreInfo());
       req.session.askedQueued = false;
       res.send(twiml.toString());
       return;
@@ -180,20 +180,20 @@ app.post('/sms', askedReminderMiddleware, (req, res, next) => {
       if (!results || results.length === 0 || results.length > 1) {
         const correctLengthCitation = text.length >= 6 && text.length <= 25;
         if (correctLengthCitation) {
-          twiml.sms(messages.notFoundAskToKeepLooking());
+          twiml.message(messages.notFoundAskToKeepLooking());
 
           req.session.citationId = text;
           req.session.askedQueued = true;
           req.session.askedReminder = false;
         } else {
-          twiml.sms(messages.invalidCaseNumber());
+          twiml.message(messages.invalidCaseNumber());
         }
       } else {
         const match = results[0];
         const name = cleanupName(match.defendant);
         const datetime = dates.fromUtc(match.date);
 
-        twiml.sms(messages.foundItAskForReminder(false, name, datetime, match.room));
+        twiml.message(messages.foundItAskForReminder(false, name, datetime, match.room));
 
         req.session.match = match;
         req.session.askedReminder = true;


### PR DESCRIPTION
This updates the twillo library to the latest version and fixes tests it broke. 

The primary changes the twilio library introduce are:

1. **A new protocol for sending messages**
 It doesn't impact our code, but breaks some tests

2. **A new function for sending the message**
 `client.messages.create()` instead of `client.sendMessage()`. It returns a promise instead of a calling back a function. We were wrapping the callback in a promise anyway, so it shouldn't impact anything.

3. **A different function for creating TwilML messages**
 `twiml.message()` vs `twiml.sms()`. This also breaks a lot of tests because the new format for TwilML is `<Response><Message>` and are tests are looking for `<Response><Sms>`

To make the tests easier to understand on item one, this changes the tests to stub out `messages.send()` instead of trying to catch the calls to Twilio with Nock. This removes the dependency on Nock everywhere except the tests for loaddata. It should make those tests much simpler to understand, less fragile, and less prone to passing when they should fail (as they currently have been). The downside to this is that we need to trust that `messages.send()` is doing what it's supposed to. Currently `messages.send()` is just a simple wrapper for the Twilio's `messages.create()`, so I think it's safe, but we might reconsider if that function ever needs to do more work.

This also moves the calls to `tk.freeze` from a position in web_test.js where it was affecting all tests in all files to the describe blocks of the tests that need it. This should help isolate tests and make it a little  easier to understand individual tests without needing to know what's going on in other files.

While I was in those files I tried to clean up some inconsistent formatting and variable declarations - this makes the PR look bigger than it really is, sorry about that.