### PR TITLE
Message change

### DIFF
--- a/test/send_reminders_test.js
+++ b/test/send_reminders_test.js
@@ -35,7 +35,7 @@ describe("with one reminder that hasn't been sent", function() {
     });
 
     it("sends the correct info to Twilio and adds a notification", function() {
-        var message = `Courtesy reminder: Frederick T Turner has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVCRT. You should confirm your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
+        var message = `Courtesy reminder: Frederick T Turner has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVCRT for case/ticket number: ${case1.case_id}. You should verify your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
         return sendReminders()
         .then(rows => {
             sinon.assert.calledWith(messageStub, request1.phone, process.env.TWILIO_PHONE_NUMBER, message)
@@ -74,7 +74,7 @@ describe("when there is an error sending the message", function(){
     });
 
     it("records the error in the notification", function(){
-        var message = `Courtesy reminder: Frederick T Turner has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVCRT. You should confirm your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
+        var message = `Courtesy reminder: Frederick T Turner has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVCRT for case/ticket number: ${case1.case_id}. You should verfify your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
         return sendReminders()
         .then(res => knex("notifications").whereIn('case_id', [case1['case_id'], case2['case_id']]).select("*"))
         .then(rows => {
@@ -103,8 +103,8 @@ describe("with three reminders (including one duplicate) that haven't been sent"
     });
 
     it("sends the correct info to Twilio, adds notification, and skips duplicate request", function () {
-        var message1 = `Courtesy reminder: Frederick T Turner has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVCRT. You should confirm your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
-        var message2 = `Courtesy reminder: Bob J Smith has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVJAIL. You should confirm your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
+        var message1 = `Courtesy reminder: Frederick T Turner has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVCRT for case/ticket number: ${case1.case_id}. You should verify your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
+        var message2 = `Courtesy reminder: Bob J Smith has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVJAIL for case/ticket number: ${case2.case_id}. You should verify your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
 
         messageMock.expects('send').resolves(true).once().withExactArgs(request1.phone, process.env.TWILIO_PHONE_NUMBER, message1)
         messageMock.expects('send').resolves(true).once().withExactArgs(request2.phone, process.env.TWILIO_PHONE_NUMBER, message2)
@@ -138,7 +138,7 @@ describe("with notification already sent for hearing", function () {
     });
 
     it("Should only send reminders to requests without existing notifications for same case_id/event time/number", function(){
-        var message = `Courtesy reminder: Bob J Smith has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVJAIL. You should confirm your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
+        var message = `Courtesy reminder: Bob J Smith has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVJAIL for case/ticket number: ${case2.case_id}. You should verify your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
         messageMock.expects('send').resolves(true).once().withExactArgs(request2.phone, process.env.TWILIO_PHONE_NUMBER, message)
 
         return knex("notifications").update({ event_date: TOMORROW_DATE})
@@ -151,8 +151,8 @@ describe("with notification already sent for hearing", function () {
     })
 
     it("should send reminder when notification exists for same phone/case_id but at a different date/time", function(){
-        var message1 = `Courtesy reminder: Frederick T Turner has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVCRT. You should confirm your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
-        var message2 = `Courtesy reminder: Bob J Smith has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVJAIL. You should confirm your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
+        var message1 = `Courtesy reminder: Frederick T Turner has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVCRT for case/ticket number: ${case1.case_id}. You should verfiy your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
+        var message2 = `Courtesy reminder: Bob J Smith has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVJAIL for case/ticket number: ${case2.case_id}. You should verfiy your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
 
         messageMock.expects('send').resolves(true).once().withExactArgs(request1.phone, process.env.TWILIO_PHONE_NUMBER, message1)
         messageMock.expects('send').resolves(true).once().withExactArgs(request2.phone, process.env.TWILIO_PHONE_NUMBER, message2)

--- a/test/send_reminders_test.js
+++ b/test/send_reminders_test.js
@@ -151,8 +151,8 @@ describe("with notification already sent for hearing", function () {
     })
 
     it("should send reminder when notification exists for same phone/case_id but at a different date/time", function(){
-        var message1 = `Courtesy reminder: Frederick T Turner has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVCRT for case/ticket number: ${case1.case_id}. You should verfiy your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
-        var message2 = `Courtesy reminder: Bob J Smith has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVJAIL for case/ticket number: ${case2.case_id}. You should verfiy your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
+        var message1 = `Courtesy reminder: Frederick T Turner has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVCRT for case/ticket number: ${case1.case_id}. You should verify your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
+        var message2 = `Courtesy reminder: Bob J Smith has a court hearing on ${TOMORROW_DATE.format('ddd, MMM Do')} at 2:00 PM, at CNVJAIL for case/ticket number: ${case2.case_id}. You should verify your hearing date and time by going to ${process.env.COURT_PUBLIC_URL}. - ${process.env.COURT_NAME}`;
 
         messageMock.expects('send').resolves(true).once().withExactArgs(request1.phone, process.env.TWILIO_PHONE_NUMBER, message1)
         messageMock.expects('send').resolves(true).once().withExactArgs(request2.phone, process.env.TWILIO_PHONE_NUMBER, message2)

--- a/test/web_test.js
+++ b/test/web_test.js
@@ -333,7 +333,7 @@ describe("POST /sms", function() {
                 .end(function (err, res) {
                     if (err)  return done(err);
 
-                    expect(res.text).to.equal('<?xml version="1.0" encoding="UTF-8"?><Response><Message>OK. We will text you a courtesy reminder the day before your hearing date. Note that court schedules frequently change. You should always confirm your hearing date and time by going to http://courts.alaska.gov.</Message></Response>');
+                    expect(res.text).to.equal('<?xml version="1.0" encoding="UTF-8"?><Response><Message>OK. We will text you a courtesy reminder the day before your hearing date. Note that court schedules frequently change. You should always verify your hearing date and time by going to http://courts.alaska.gov.</Message></Response>');
                     expect(getConnectCookie(sess).case_id).to.be.undefined;
                     expect(getConnectCookie(sess).known_case).to.be.undefined;
 

--- a/utils/messages.js
+++ b/utils/messages.js
@@ -145,8 +145,9 @@ function notFoundAskToKeepLooking() {
  */
 function reminder(occurrence) {
     return normalizeSpaces(`Courtesy reminder: ${cleanupName(occurrence.defendant)} has a court hearing on
-        ${moment(occurrence.date).format('ddd, MMM Do')} at ${moment(occurrence.date).format('h:mm A')}, at ${occurrence.room}.
-        You should confirm your hearing date and time by going to
+        ${moment(occurrence.date).format('ddd, MMM Do')} at ${moment(occurrence.date).format('h:mm A')}, at ${occurrence.room}
+        for case/ticket number: ${occurrence.case_id}.
+        You should verify your hearing date and time by going to
         ${process.env.COURT_PUBLIC_URL}.
         - ${process.env.COURT_NAME}`);
 }

--- a/utils/messages.js
+++ b/utils/messages.js
@@ -182,7 +182,7 @@ function weWillKeepLooking() {
 function weWillRemindYou() {
     return normalizeSpaces(`OK. We will text you a courtesy reminder
         the day before your hearing date. Note that court schedules frequently change.
-        You should always confirm your hearing date and time by going
+        You should always verify your hearing date and time by going
         to ${process.env.COURT_PUBLIC_URL}.`);
 }
 


### PR DESCRIPTION
Replaces the word 'confirm' with 'verify' in messages to users so it doesn't appear they need to confirm hearing dates, but should only double check that they are correct. Also includes case/ticket number in reminder message.