### PR TITLE
specify versions required for node and pg

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The database also has tables *log_hits* and *log_runners*. These log activity of
 
 ## Running Locally
 
-First, install [node](https://github.com/codeforamerica/howto/blob/master/Node.js.md), [postgres](https://github.com/codeforamerica/howto/blob/master/PostgreSQL.md).
+First, install [node](https://github.com/codeforamerica/howto/blob/master/Node.js.md) (atleast version 7.6), and [postgres](https://github.com/codeforamerica/howto/blob/master/PostgreSQL.md) (atleast version 9.5).
 
 Then clone the repository into a folder called courtbot:
 


### PR DESCRIPTION
I had been running node v6 on one of my workstations and was having problems with the async functions syntax-- which isn't supported until v7.6 and above.  I was also running PostgreSQL server 9.4 which cannot handle the 'ON CONFLICT' clause (but it is supported in v9.5 and above).  Once I updated those it was smooth sailing...